### PR TITLE
Added UseHostName variable to allow to use -HostName instead -ComputerName parameter and -Username even do when no password is provided

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -11,6 +11,7 @@ type Settings struct {
 	Username              string
 	Password              string
 	Credential            string
+	UseHostName           bool
 	AllowRedirection      bool
 	Authentication        string
 	CertificateThumbprint string
@@ -39,8 +40,17 @@ func (s *Settings) ToArgs() []string {
 	args := make([]string, 0)
 
 	if s.ComputerName != "" {
-		args = append(args, "-ComputerName")
+		if s.UseHostName {
+			args = append(args, "-HostName")
+		} else {
+			args = append(args, "-ComputerName")
+		}
 		args = append(args, quoteArg(s.ComputerName))
+	}
+
+	if s.Username != "" {
+		args = append(args, "-Username")
+		args = append(args, quoteArg(s.Username))
 	}
 
 	if s.AllowRedirection {

--- a/powershell_option.go
+++ b/powershell_option.go
@@ -20,6 +20,16 @@ func (w withUsernamePassword) Apply(o *internal.Settings) {
 	o.Password = w.password
 }
 
+type useHostName bool
+
+func UseHostName() Option {
+	return useHostName(true)
+}
+
+func (w useHostName) Apply(o *internal.Settings) {
+	o.UseHostName = bool(w)
+}
+
 type withAllowRedirection bool
 
 func WithAllowRedirection() Option {


### PR DESCRIPTION
If someone use Linux and want to get Powershell objects you need to Specify -HostName and -Username parameters without password (using ssh keys), hope you can add this changes, if you want to test it using Linux and ssh keys let me know